### PR TITLE
Add ability to set custom database directory path

### DIFF
--- a/Sources/Amplitude/AMPUtils.h
+++ b/Sources/Amplitude/AMPUtils.h
@@ -31,4 +31,6 @@
 + (NSDictionary*)validateGroups:(NSDictionary*) obj;
 + (NSString*)platformDataDirectory;
 
++ (void)setCustomPlatformDataDirectoryPath:(NSString *)platformDataDirectoryPath;
+
 @end

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -38,7 +38,7 @@
 @interface AMPUtils()
 @end
 
-static NSString *customPlatformDaraDirectoryPath = nil;
+static NSString *customPlatformDataDirectoryPath = nil;
 
 @implementation AMPUtils
 
@@ -152,13 +152,13 @@ static NSString *customPlatformDaraDirectoryPath = nil;
 #if TARGET_OS_TV
     return [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
 #else
-    return customPlatformDaraDirectoryPath ? : [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
+    return customPlatformDataDirectoryPath ? : [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
 #endif
 }
 
 + (void)setCustomPlatformDataDirectoryPath:(NSString *)platformDataDirectoryPath
 {
-    customPlatformDaraDirectoryPath = platformDataDirectoryPath;
+    customPlatformDataDirectoryPath = platformDataDirectoryPath;
 }
 
 @end

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -38,6 +38,8 @@
 @interface AMPUtils()
 @end
 
+static NSString *customPlatformDaraDirectoryPath = nil;
+
 @implementation AMPUtils
 
 + (instancetype)alloc {
@@ -150,8 +152,13 @@
 #if TARGET_OS_TV
     return [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
 #else
-    return [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
+    return customPlatformDaraDirectoryPath ? : [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
 #endif
+}
+
++ (void)setCustomPlatformDataDirectoryPath:(NSString *)platformDataDirectoryPath
+{
+    customPlatformDaraDirectoryPath = platformDataDirectoryPath;
 }
 
 @end

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -38,7 +38,7 @@
 @interface AMPUtils()
 @end
 
-static NSString *customPlatformDataDirectoryPath = nil;
+static NSString *_customPlatformDataDirectoryPath = nil;
 
 @implementation AMPUtils
 
@@ -152,13 +152,13 @@ static NSString *customPlatformDataDirectoryPath = nil;
 #if TARGET_OS_TV
     return [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
 #else
-    return customPlatformDataDirectoryPath ? : [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
+    return _customPlatformDataDirectoryPath ? : [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
 #endif
 }
 
 + (void)setCustomPlatformDataDirectoryPath:(NSString *)platformDataDirectoryPath
 {
-    customPlatformDataDirectoryPath = platformDataDirectoryPath;
+    _customPlatformDataDirectoryPath = platformDataDirectoryPath;
 }
 
 @end

--- a/Sources/Amplitude/Amplitude.h
+++ b/Sources/Amplitude/Amplitude.h
@@ -145,6 +145,18 @@
 + (Amplitude *)instance;
 
 /**
+ This fetches the default SDK instance. Recommended if you are only logging events to a single app.
+ 
+ Additionally this method sets custom custom path for local data to allow host application
+ locate service files in desired directory
+
+ @param dataDirectoryPath path to custom directory to keep all related data.
+ 
+ @returns the default Amplitude SDK instance
+ */
++ (Amplitude *)instanceWithDataDirectoryPath:(NSString *)dataDirectoryPath;
+
+/**
  This fetches a named SDK instance. Use this if logging events to multiple Amplitude apps.
 
  @param instanceName the name of the SDK instance to fetch.

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -144,6 +144,11 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return [Amplitude instanceWithName:nil];
 }
 
++ (Amplitude *)instanceWithDataDirectoryPath:(NSString *)dataDirectoryPath {
+    [AMPUtils setCustomPlatformDataDirectoryPath:dataDirectoryPath];
+    return [self instance];
+}
+
 + (Amplitude *)instanceWithName:(NSString*)instanceName {
     static NSMutableDictionary *_instances = nil;
     static dispatch_once_t onceToken;


### PR DESCRIPTION
# What
Due to its iOS origin, Amplitude framework uses `~/Library/com.amplitude.database` path to locate its events database. For unsandboxed applications it results in using the same database file for different applications and messes up events between them.

The purpose of this PR is to add an ability for Amplitude to set custom `data directory path` to avoid such situations. 

# Approach
The approach proposed in this PR is pretty dummy and straightforward, but I was trying to make as little changes as possible to avoid a big impact on framework and reduce time of retesting it.